### PR TITLE
chore: update fallback version and improve error handling in installer

### DIFF
--- a/.azuredevops/release.yaml
+++ b/.azuredevops/release.yaml
@@ -11,29 +11,32 @@ resources:
 trigger: none
 pr: none
 
-jobs:
-  - template: templates/publish.yaml
-    parameters:
-      marketplaceConnection: e5af4fa9-9ce8-48be-88bf-ad06b71c2017
-      publisherId: bonddim
-      extensionId: argocd-installer
-      extensionName: Argo CD CLI Installer
-      extensionVisibility: public
+stages:
+  - stage: Release
+    trigger: manual
+    jobs:
+      - template: templates/publish.yaml
+        parameters:
+          marketplaceConnection: e5af4fa9-9ce8-48be-88bf-ad06b71c2017
+          publisherId: bonddim
+          extensionId: argocd-installer
+          extensionName: Argo CD CLI Installer
+          extensionVisibility: public
 
-  - job: Release
-    dependsOn: publish
-    variables:
-      version: $[ dependencies.publish.outputs['QueryVersion.Extension.Version'] ]
-    steps:
-      - checkout: none
-      - task: GitHubRelease@1
-        inputs:
-          gitHubConnection: 6de9605e-eb3c-4e78-8ef0-41ea94aa7918
-          repositoryName: $(Build.Repository.Name)
-          action: create
-          changeLogCompareToRelease: lastFullRelease
-          changeLogType: commitBased
-          target: $(Build.SourceVersion)
-          tagSource: userSpecifiedTag
-          tag: v$(version)
-          title: v$(version)
+      - job: Release
+        dependsOn: publish
+        variables:
+          version: $[ dependencies.publish.outputs['QueryVersion.Extension.Version'] ]
+        steps:
+          - checkout: none
+          - task: GitHubRelease@1
+            inputs:
+              gitHubConnection: 6de9605e-eb3c-4e78-8ef0-41ea94aa7918
+              repositoryName: $(Build.Repository.Name)
+              action: create
+              changeLogCompareToRelease: lastFullRelease
+              changeLogType: commitBased
+              target: $(Build.SourceVersion)
+              tagSource: userSpecifiedTag
+              tag: v$(version)
+              title: v$(version)


### PR DESCRIPTION
This pull request includes significant changes to the `installer/index.ts` file to improve error handling and update the fallback version, as well as updates to the release pipeline configuration in `.azuredevops/release.yaml`.

Improvements to error handling and version resolution:

* [`installer/index.ts`](diffhunk://#diff-f6d3ea4353e90c671787617c35d8af8050579f49787330d30c9883882467faecL6-L37): Updated the fallback version from `v2.14.2` to `v2.14.5`.
* [`installer/index.ts`](diffhunk://#diff-f6d3ea4353e90c671787617c35d8af8050579f49787330d30c9883882467faecL130-R126): Improved error handling by adding a `.catch` block to the `run` function and removing the `try-catch` block within the function.
* [`installer/index.ts`](diffhunk://#diff-f6d3ea4353e90c671787617c35d8af8050579f49787330d30c9883882467faecR59-R66): Enhanced logging by adding console log statements in `resolveLatest` and `resolveServer` functions to indicate the URL being resolved. [[1]](diffhunk://#diff-f6d3ea4353e90c671787617c35d8af8050579f49787330d30c9883882467faecR59-R66) [[2]](diffhunk://#diff-f6d3ea4353e90c671787617c35d8af8050579f49787330d30c9883882467faecR75-R88)
* [`installer/index.ts`](diffhunk://#diff-f6d3ea4353e90c671787617c35d8af8050579f49787330d30c9883882467faecL108-R98): Modified the `installCli` function to return the cached path instead of directly prepending it to the tool path.

Release pipeline configuration:

* [`.azuredevops/release.yaml`](diffhunk://#diff-b06c08b06e1a435034a22afc5f06111cb2bbabb7d8fd4359d10d7f88a1d2a8f8R14-R16): Added a new `stages` section with a `Release` stage triggered manually.